### PR TITLE
Tests fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install: 
+  - pip install .
+
+script:
+  - py.test

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/scott-griffiths/bitstring.svg?branch=master
+    :target: https://travis-ci.org/scott-griffiths/bitstring
+
 ================
 bitstring module
 ================

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Searching, inserting and deleting::
 Unit Tests
 ----------
 
-The 400+ unit tests should all pass for Python 2.6 and later.
+The 400+ unit tests should all pass for Python 2.7 and later.
 
 ----
 

--- a/test/test_bitstream.py
+++ b/test/test_bitstream.py
@@ -11,6 +11,9 @@ from bitstring import BitStream, ConstBitStream, pack
 from bitstring import ByteStore, offsetcopy
 
 
+os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+
 class FlexibleInitialisation(unittest.TestCase):
     def testFlexibleInitialisation(self):
         a = BitStream('uint:8=12')


### PR DESCRIPTION
This PR will fix the with the tests not finding the test files.

Also I added a travis file to run tests on 2.7 up to 3.6. But to get the badge displaying you will have to register your github account on https://travis-ci.org/ and activate this repository **before** merging this PR.

I thought it might be nice to see test results on all python versions. Hope that is ok with you.

Fix #171 