### PR TITLE
Improve type consistency with length=1 specification for bool

### DIFF
--- a/bitstring.py
+++ b/bitstring.py
@@ -601,8 +601,8 @@ def tokenparser(fmt, keys=None, token_cache={}):
                 if m2.group('value'):
                     value = m2.group('value')
             if name == 'bool':
-                if length is not None:
-                    raise ValueError("You can't specify a length with bool tokens - they are always one bit.")
+                if length is not None and length != '1':
+                    raise ValueError("You can only specify one bit sized bool tokens or leave unspecified.")
                 length = 1
             if length is None and name not in ('se', 'ue', 'sie', 'uie'):
                 stretchy_token = True

--- a/test/test_bits.py
+++ b/test/test_bits.py
@@ -131,6 +131,8 @@ class Creation(unittest.TestCase):
         self.assertEqual(b, [0])
         c = bitstring.pack('2*bool', 0, 1)
         self.assertEqual(c, '0b01')
+        d = bitstring.pack('2*bool:1', 1, 0)
+        self.assertEqual(d, '0b10')
 
     def testCreationKeywordError(self):
         self.assertRaises(bitstring.CreationError, Bits, squirrel=5)

--- a/test/test_bitstream.py
+++ b/test/test_bitstream.py
@@ -3786,7 +3786,6 @@ class BoolToken(unittest.TestCase):
     def testLengthWithBoolRead(self):
         a = ConstBitStream('0xf')
         self.assertRaises(ValueError, a.read, 'bool:0')
-        self.assertRaises(ValueError, a.read, 'bool:1')
         self.assertRaises(ValueError, a.read, 'bool:2')
 
 


### PR DESCRIPTION
For any code using bitstring with types and lengths given at runtime,
packing and unpacking requires special treatment for bools because
they require that no length specification is supplied.

Allowing a specification of length=1 maintains safety and correctness
while reducing the complexity of code using bitstring.