### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility.

### DIFF
--- a/bitstring.py
+++ b/bitstring.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""
+r"""
 This package defines classes that simplify bit-wise creation, manipulation and
 interpretation of data.
 

--- a/bitstring.py
+++ b/bitstring.py
@@ -72,8 +72,12 @@ import mmap
 import os
 import struct
 import operator
-import collections
 import array
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 byteorder = sys.byteorder
 
@@ -1311,7 +1315,7 @@ class Bits(object):
             data = bytearray((s + 7) // 8)
             self._datastore = ByteStore(data, s, 0)
             return
-        if isinstance(s, collections.Iterable):
+        if isinstance(s, Iterable):
             # Evaluate each item as True or False and set bits to 1 or 0.
             self._setbin_unsafe(''.join(str(int(bool(x))) for x in s))
             return
@@ -3501,7 +3505,7 @@ class BitArray(Bits):
         if pos is None:
             self._invert_all()
             return
-        if not isinstance(pos, collections.Iterable):
+        if not isinstance(pos, Iterable):
             pos = (pos,)
         length = self.len
 
@@ -3589,7 +3593,7 @@ class BitArray(Bits):
                     bytesizes.append(PACK_CODE_SIZE[f])
                 else:
                     bytesizes.extend([PACK_CODE_SIZE[f[-1]]] * int(f[:-1]))
-        elif isinstance(fmt, collections.Iterable):
+        elif isinstance(fmt, Iterable):
             bytesizes = fmt
             for bytesize in bytesizes:
                 if not isinstance(bytesize, numbers.Integral) or bytesize < 0:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -215,7 +215,7 @@ titlepage = """
 \\cleardoublepage
 """ % release
 
-latex_elements = {'preamble': '\setcounter{tocdepth}{2}\definecolor{VerbatimBorderColor}{rgb}{1,1,1}',
+latex_elements = {'preamble': r'\setcounter{tocdepth}{2}\definecolor{VerbatimBorderColor}{rgb}{1,1,1}',
                   'fncychap': '\\usepackage[Sonny]{fncychap}',
                   'maketitle': titlepage,
                   'papersize': 'a4paper',

--- a/test/test_bitstream.py
+++ b/test/test_bitstream.py
@@ -6,7 +6,12 @@ sys.path.insert(0, '..')
 import bitstring
 import copy
 import os
-import collections
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from bitstring import BitStream, ConstBitStream, pack
 from bitstring import offsetcopy
 
@@ -3457,7 +3462,7 @@ class Bugs(unittest.TestCase):
         self.assertEqual(s.len, 17)
 
     def testInitFromIterable(self):
-        self.assertTrue(isinstance(range(10), collections.Iterable))
+        self.assertTrue(isinstance(range(10), Iterable))
         s = ConstBitStream(range(12))
         self.assertEqual(s, '0x7ff')
 


### PR DESCRIPTION
Fixes #196 . Fixes invalid escape sequences as below.

```
$ find . -iname '*.py'  | xargs -P 4 -I{} python3.8 -Wall -m py_compile {}

./doc/conf.py:218: DeprecationWarning: invalid escape sequence \s
  latex_elements = {'preamble': '\setcounter{tocdepth}{2}\definecolor{VerbatimBorderColor}{rgb}{1,1,1}',
./bitstring.py:2: DeprecationWarning: invalid escape sequence \ 
  """
```