### PR TITLE
Duplicate backslashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install: 
   - pip install .

--- a/bitstring.py
+++ b/bitstring.py
@@ -11,13 +11,13 @@ ConstBitStream -- An immutable container with streaming methods.
 BitStream -- A mutable container with streaming methods.
 
                       Bits (base class)
-                     /    \
- + mutating methods /      \ + streaming methods
-                   /        \
+                     //    \\
+ + mutating methods //      \\ + streaming methods
+                   //        \\
               BitArray   ConstBitStream
-                   \        /
-                    \      /
-                     \    /
+                   \\        //
+                    \\      //
+                     \\    //
                     BitStream
 
 Functions:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -215,7 +215,7 @@ titlepage = """
 \\cleardoublepage
 """ % release
 
-latex_elements = {'preamble': '\setcounter{tocdepth}{2}\definecolor{VerbatimBorderColor}{rgb}{1,1,1}',
+latex_elements = {'preamble': '\\setcounter{tocdepth}{2}\\definecolor{VerbatimBorderColor}{rgb}{1,1,1}',
                   'fncychap': '\\usepackage[Sonny]{fncychap}',
                   'maketitle': titlepage,
                   'papersize': 'a4paper',


### PR DESCRIPTION
DeprecationWarning: invalid escape sequence \
(backslash+space) in Python 3.8