### PR TITLE
Use raw string literal to fix "invalid escape sequence" warning

### DIFF
--- a/bitstring.py
+++ b/bitstring.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""
+r"""
 This package defines classes that simplify bit-wise creation, manipulation and
 interpretation of data.
 


### PR DESCRIPTION
Fixes #207.