### PR TITLE
Update documentation links used on GitHub Pages page

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,22 +72,22 @@
             <a id="documentation" class="anchor" href="#documentation" aria-hidden="true"><span
                     class="octicon octicon-link"></span></a>Documentation</h1>
 
-        <p><a href="http://packages.python.org/bitstring">http://packages.python.org/bitstring</a> Latest documentation
+        <p><a href="https://bitstring.readthedocs.io/">https://bitstring.readthedocs.io/</a> Latest documentation
         </p>
 
         <p>Some quick links to useful parts of the docs:</p>
 
         <ul>
-            <li><a href="http://packages.python.org/bitstring/walkthrough.html">Brief Walkthrough</a></li>
+            <li><a href="https://bitstring.readthedocs.io/en/latest/walkthrough.html">Brief Walkthrough</a></li>
             <li>
-                <a href="http://packages.python.org/bitstring/creation.html">Bitstring Creation and Interpretation</a>
+                <a href="https://bitstring.readthedocs.io/en/latest/creation.html">Bitstring Creation and Interpretation</a>
             </li>
             <li>
-                <a href="http://packages.python.org/bitstring/reading.html">Reading, Parsing and Unpacking</a></li>
+                <a href="https://bitstring.readthedocs.io/en/latest/reading.html">Reading, Parsing and Unpacking</a></li>
             <li>
-                <a href="http://packages.python.org/bitstring/quick_ref.html">Module Quick Reference</a></li>
+                <a href="https://bitstring.readthedocs.io/en/latest/quick_ref.html">Module Quick Reference</a></li>
             <li>
-                <a href="http://packages.python.org/bitstring/reference.html">Full Module Reference</a></li>
+                <a href="https://bitstring.readthedocs.io/en/latest/reference.html">Full Module Reference</a></li>
         </ul>
 
         <hr>
@@ -96,7 +96,7 @@
             <a id="examples" class="anchor" href="#examples" aria-hidden="true"><span
                     class="octicon octicon-link"></span></a>Examples</h1>
 
-        <p>See the <a href="http://packages.python.org/bitstring/examples.html">user manual</a> for more examples.</p>
+        <p>See the <a href="https://bitstring.readthedocs.io/en/latest/examples.html">user manual</a> for more examples.</p>
 
         <p>Creation:</p>
 


### PR DESCRIPTION
The GitHub Pages page is still alive (and Google-indexed). Existing documentation links there were broken, so I've updated to latest readthedocs instance.