### PR TITLE
Run `python -m unittest discover -s test` from root.

### DIFF
--- a/test/test_bits.py
+++ b/test/test_bits.py
@@ -6,8 +6,11 @@ import sys
 sys.path.insert(0, '..')
 import bitstring
 import array
+import os
 from bitstring import MmapByteArray
 from bitstring import Bits, BitArray, ConstByteStore
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 class Creation(unittest.TestCase):
@@ -243,10 +246,11 @@ class InterleavedExpGolomb(unittest.TestCase):
 
 class FileBased(unittest.TestCase):
     def setUp(self):
-        self.a = Bits(filename='smalltestfile')
-        self.b = Bits(filename='smalltestfile', offset=16)
-        self.c = Bits(filename='smalltestfile', offset=20, length=16)
-        self.d = Bits(filename='smalltestfile', offset=20, length=4)
+        filename = os.path.join(THIS_DIR, 'smalltestfile')
+        self.a = Bits(filename=filename)
+        self.b = Bits(filename=filename, offset=16)
+        self.c = Bits(filename=filename, offset=20, length=16)
+        self.d = Bits(filename=filename, offset=20, length=4)
 
     def testCreationWithOffset(self):
         self.assertEqual(self.a, '0x0123456789abcdef')
@@ -272,7 +276,7 @@ class FileBased(unittest.TestCase):
         
 class Mmap(unittest.TestCase):
     def setUp(self):
-        self.f = open('smalltestfile', 'rb')
+        self.f = open(os.path.join(THIS_DIR, 'smalltestfile'), 'rb')
 
     def tearDown(self):
         self.f.close()

--- a/test/test_bitstream.py
+++ b/test/test_bitstream.py
@@ -10,6 +10,8 @@ import collections
 from bitstring import BitStream, ConstBitStream, pack
 from bitstring import offsetcopy
 
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
 try:
     collectionsAbc = collections.abc
 except AttributeError:  # Python 2.7
@@ -659,48 +661,49 @@ class Unpack(unittest.TestCase):
 
 class FromFile(unittest.TestCase):
     def testCreationFromFileOperations(self):
-        s = BitStream(filename='smalltestfile')
+        filename = os.path.join(THIS_DIR, 'smalltestfile')
+        s = BitStream(filename=filename)
         s.append('0xff')
         self.assertEqual(s.hex, '0123456789abcdefff')
 
-        s = ConstBitStream(filename='smalltestfile')
+        s = ConstBitStream(filename=filename)
         t = BitStream('0xff') + s
         self.assertEqual(t.hex, 'ff0123456789abcdef')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         del s[:1]
         self.assertEqual((BitStream('0b0') + s).hex, '0123456789abcdef')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         del s[:7 * 8]
         self.assertEqual(s.hex, 'ef')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         s.insert('0xc', 4)
         self.assertEqual(s.hex, '0c123456789abcdef')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         s.prepend('0xf')
         self.assertEqual(s.hex, 'f0123456789abcdef')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         s.overwrite('0xaaa', 12)
         self.assertEqual(s.hex, '012aaa6789abcdef')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         s.reverse()
         self.assertEqual(s.hex, 'f7b3d591e6a2c480')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         del s[-60:]
         self.assertEqual(s.hex, '0')
 
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=filename)
         del s[:60]
         self.assertEqual(s.hex, 'f')
 
     def testFileProperties(self):
-        s = ConstBitStream(filename='smalltestfile')
+        s = ConstBitStream(filename=os.path.join(THIS_DIR, 'smalltestfile'))
         self.assertEqual(s.hex, '0123456789abcdef')
         self.assertEqual(s.uint, 81985529216486895)
         self.assertEqual(s.int, 81985529216486895)
@@ -714,34 +717,37 @@ class FromFile(unittest.TestCase):
         self.assertEqual(s.tobytes(), b'\x01\x23\x45\x67\x89\xab\xcd\xef')
 
     def testCreationFromFileWithLength(self):
-        s = ConstBitStream(filename='test.m1v', length=32)
+        test_filename = os.path.join(THIS_DIR, 'test.m1v')
+        s = ConstBitStream(filename=test_filename, length=32)
         self.assertEqual(s.length, 32)
         self.assertEqual(s.hex, '000001b3')
-        s = ConstBitStream(filename='test.m1v', length=0)
+        s = ConstBitStream(filename=test_filename, length=0)
         self.assertFalse(s)
-        self.assertRaises(bitstring.CreationError, BitStream, filename='smalltestfile', length=65)
-        self.assertRaises(bitstring.CreationError, ConstBitStream, filename='smalltestfile', length=64, offset=1)
-        #        self.assertRaises(bitstring.CreationError, ConstBitStream, filename='smalltestfile', offset=65)
-        with open('smalltestfile', 'rb') as f:
+        smalltest_filename = os.path.join(THIS_DIR, 'smalltestfile')
+        self.assertRaises(bitstring.CreationError, BitStream, filename=smalltest_filename, length=65)
+        self.assertRaises(bitstring.CreationError, ConstBitStream, filename=smalltest_filename, length=64, offset=1)
+        #        self.assertRaises(bitstring.CreationError, ConstBitStream, filename=smalltest_filename, offset=65)
+        with open(smalltest_filename, 'rb') as f:
             #        self.assertRaises(bitstring.CreationError, ConstBitStream, auto=f, offset=65)
             self.assertRaises(bitstring.CreationError, ConstBitStream, auto=f, length=65)
             self.assertRaises(bitstring.CreationError, ConstBitStream, auto=f, offset=60, length=5)
 
     def testCreationFromFileWithOffset(self):
-        a = BitStream(filename='test.m1v', offset=4)
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        a = BitStream(filename=filename, offset=4)
         self.assertEqual(a.peek(4 * 8).hex, '00001b31')
-        b = BitStream(filename='test.m1v', offset=28)
+        b = BitStream(filename=filename, offset=28)
         self.assertEqual(b.peek(8).hex, '31')
 
     def testFileSlices(self):
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=os.path.join(THIS_DIR, 'smalltestfile'))
         self.assertEqual(s[-16:].hex, 'cdef')
 
     def testCreataionFromFileErrors(self):
         self.assertRaises(IOError, BitStream, filename='Idonotexist')
 
     def testFindInFile(self):
-        s = BitStream(filename='test.m1v')
+        s = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'))
         self.assertTrue(s.find('0x160120'))
         self.assertEqual(s.bytepos, 4)
         s3 = s.read(24)
@@ -752,15 +758,16 @@ class FromFile(unittest.TestCase):
         self.assertEqual(s.bytepos, 13)
 
     def testHexFromFile(self):
-        s = BitStream(filename='test.m1v')
+        s = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'))
         self.assertEqual(s[0:32].hex, '000001b3')
         self.assertEqual(s[-32:].hex, '000001b7')
         s.hex = '0x11'
         self.assertEqual(s.hex, '11')
 
     def testFileOperations(self):
-        s1 = BitStream(filename='test.m1v')
-        s2 = BitStream(filename='test.m1v')
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        s1 = BitStream(filename=filename)
+        s2 = BitStream(filename=filename)
         self.assertEqual(s1.read(32).hex, '000001b3')
         self.assertEqual(s2.read(32).hex, '000001b3')
         s1.bytepos += 4
@@ -774,7 +781,7 @@ class FromFile(unittest.TestCase):
             pass
 
     def testFileBitGetting(self):
-        s = ConstBitStream(filename='smalltestfile', offset=16, length=8) # 0x45
+        s = ConstBitStream(filename=os.path.join(THIS_DIR, 'smalltestfile'), offset=16, length=8) # 0x45
         b = s[1]
         self.assertTrue(b)
         b = s.any(0, [-1, -2, -3])
@@ -786,7 +793,7 @@ class FromFile(unittest.TestCase):
         # This uses an 11GB file which isn't distributed for obvious reasons
         # and so this test won't work for anyone except me!
         try:
-            s = ConstBitStream(filename='11GB.mkv')
+            s = ConstBitStream(filename=os.path.join(THIS_DIR, '11GB.mkv'))
         except IOError:
             return
         self.assertEqual(s.len, 11743020505 * 8)
@@ -1643,7 +1650,7 @@ class Multiplication(unittest.TestCase):
         self.assertEqual(q.bitpos, 0)
 
     def testMultiplicationWithFiles(self):
-        a = BitStream(filename='test.m1v')
+        a = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'))
         b = a.len
         a *= 3
         self.assertEqual(a.len, 3 * b)
@@ -1659,8 +1666,9 @@ class Multiplication(unittest.TestCase):
         self.assertRaises(TypeError, a.__imul__, b)
 
     def testFileAndMemEquivalence(self):
-        a = ConstBitStream(filename='smalltestfile')
-        b = BitStream(filename='smalltestfile')
+        filename = os.path.join(THIS_DIR, 'smalltestfile')
+        a = ConstBitStream(filename=filename)
+        b = BitStream(filename=filename)
         self.assertTrue(isinstance(a._datastore._rawarray, bitstring.MmapByteArray))
         self.assertTrue(isinstance(b._datastore._rawarray, bytearray))
         self.assertEqual(a._datastore.getbyte(0), b._datastore.getbyte(0))
@@ -1921,9 +1929,10 @@ class Split(unittest.TestCase):
             a = BitStream(bs)
             b = eval(a.__repr__())
             self.assertTrue(a == b)
-        for f in [ConstBitStream(filename='test.m1v'),
-                  ConstBitStream(filename='test.m1v', length=17),
-                  ConstBitStream(filename='test.m1v', length=23, offset=23102)]:
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        for f in [ConstBitStream(filename=filename),
+                  ConstBitStream(filename=filename, length=17),
+                  ConstBitStream(filename=filename, length=23, offset=23102)]:
             f2 = eval(f.__repr__())
             self.assertEqual(f._datastore._rawarray.source.name, f2._datastore._rawarray.source.name)
             self.assertTrue(f2.tobytes() == f.tobytes())
@@ -1943,7 +1952,7 @@ class Split(unittest.TestCase):
     def testPrint(self):
         s = BitStream(hex='0x00')
         self.assertEqual('0x' + s.hex, s.__str__())
-        s = BitStream(filename='test.m1v')
+        s = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'))
         self.assertEqual('0x' + s[0:bitstring.MAX_CHARS * 4].hex + '...', s.__str__())
         self.assertEqual(BitStream().__str__(), '')
         s = BitStream('0b11010')
@@ -2309,38 +2318,40 @@ class Split(unittest.TestCase):
         self.assertEqual(a.tobytes(), b'\xab')
 
     def testToFile(self):
+        filename = os.path.join(THIS_DIR, 'temp_bitstring_unit_testing_file')
         a = BitStream('0x0000ff')[:17]
-        f = open('temp_bitstring_unit_testing_file', 'wb')
+        f = open(filename, 'wb')
         a.tofile(f)
         f.close()
-        b = BitStream(filename='temp_bitstring_unit_testing_file')
+        b = BitStream(filename=filename)
         self.assertEqual(b, '0x000080')
 
         a = BitStream('0x911111')
         del a[:1]
         self.assertEqual(a + '0b0', '0x222222')
-        f = open('temp_bitstring_unit_testing_file', 'wb')
+        f = open(filename, 'wb')
         a.tofile(f)
         f.close()
-        b = BitStream(filename='temp_bitstring_unit_testing_file')
+        b = BitStream(filename=filename)
         self.assertEqual(b, '0x222222')
-        os.remove('temp_bitstring_unit_testing_file')
+        os.remove(filename)
 
     #def testToFileWithLargerFile(self):
+    #    filename = os.path.join(THIS_DIR, 'temp_bitstring_unit_testing_file')
     #    a = BitStream(length=16000000)
     #    a[1] = '0b1'
     #    a[-2] = '0b1'
-    #    f = open('temp_bitstring_unit_testing_file' ,'wb')
+    #    f = open(filename, 'wb')
     #    a.tofile(f)
     #    f.close()
-    #    b = BitStream(filename='temp_bitstring_unit_testing_file')
+    #    b = BitStream(filename=filename)
     #    self.assertEqual(b.len, 16000000)
     #    self.assertEqual(b[1], True)
     #
-    #    f = open('temp_bitstring_unit_testing_file' ,'wb')
+    #    f = open(filename, 'wb')
     #    a[1:].tofile(f)
     #    f.close()
-    #    b = BitStream(filename='temp_bitstring_unit_testing_file')
+    #    b = BitStream(filename=filename)
     #    self.assertEqual(b.len, 16000000)
     #    self.assertEqual(b[0], True)
     #    os.remove('temp_bitstring_unit_testing_file')
@@ -2363,7 +2374,8 @@ class Split(unittest.TestCase):
         self.assertEqual(tp('2*bits:6'), (False, [('bits', 6, None), ('bits', 6, None)]))
 
     def testAutoFromFileObject(self):
-        with open('test.m1v', 'rb') as f:
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        with open(filename, 'rb') as f:
             s = ConstBitStream(f, offset=32, length=12)
             self.assertEqual(s.uint, 352)
             t = ConstBitStream('0xf') + f
@@ -2373,13 +2385,13 @@ class Split(unittest.TestCase):
             t2.prepend(s2)
             self.assertTrue(t2.startswith('0x000001b3'))
             self.assertTrue(t2.endswith('0xc'))
-            with open('test.m1v', 'rb') as b:
+            with open(filename, 'rb') as b:
                 u = BitStream(bytes=b.read())
                 # TODO: u == s2 is much slower than u.bytes == s2.bytes
                 self.assertEqual(u.bytes, s2.bytes)
 
     def testFileBasedCopy(self):
-        with open('smalltestfile', 'rb') as f:
+        with open(os.path.join(THIS_DIR, 'smalltestfile'), 'rb') as f:
             s = BitStream(f)
             t = BitStream(s)
             s.prepend('0b1')
@@ -2897,10 +2909,11 @@ class Set(unittest.TestCase):
         self.assertRaises(IndexError, a.set, 1, [-11])
 
     def testFileBasedSetUnset(self):
-        a = BitStream(filename='test.m1v')
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        a = BitStream(filename=filename)
         a.set(True, (0, 1, 2, 3, 4))
         self.assertEqual(a[0:32], '0xf80001b3')
-        a = BitStream(filename='test.m1v')
+        a = BitStream(filename=filename)
         a.set(False, (28, 29, 30, 31))
         self.assertTrue(a.startswith('0x000001b0'))
 
@@ -2978,7 +2991,7 @@ class Invert(unittest.TestCase):
         a = BitStream('0b0101010101000')
         a &= '0b1111110000000'
         self.assertEqual(a, '0b0101010000000')
-        s = BitStream(filename='test.m1v', offset=26, length=24)
+        s = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'), offset=26, length=24)
         s &= '0xff00ff'
         self.assertEqual(s, '0xcc0004')
 
@@ -3003,15 +3016,17 @@ class AllAndAny(unittest.TestCase):
         self.assertFalse(a.all(True, [0]))
 
     def testFileBasedAll(self):
-        a = BitStream(filename='test.m1v')
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        a = BitStream(filename=filename)
         self.assertTrue(a.all(True, [31]))
-        a = BitStream(filename='test.m1v')
+        a = BitStream(filename=filename)
         self.assertTrue(a.all(False, (0, 1, 2, 3, 4)))
 
     def testFileBasedAny(self):
-        a = BitStream(filename='test.m1v')
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        a = BitStream(filename=filename)
         self.assertTrue(a.any(True, (31, 12)))
-        a = BitStream(filename='test.m1v')
+        a = BitStream(filename=filename)
         self.assertTrue(a.any(False, (0, 1, 2, 3, 4)))
 
     def testAny(self):
@@ -3196,7 +3211,7 @@ class AllAndAny(unittest.TestCase):
         self.assertEqual(a, '0b1')
 
     def testRolFromFile(self):
-        a = BitStream(filename='test.m1v')
+        a = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'))
         l = a.len
         a.rol(1)
         self.assertTrue(a.startswith('0x000003'))
@@ -3204,7 +3219,7 @@ class AllAndAny(unittest.TestCase):
         self.assertTrue(a.endswith('0x0036e'))
 
     def testRorFromFile(self):
-        a = BitStream(filename='test.m1v')
+        a = BitStream(filename=os.path.join(THIS_DIR, 'test.m1v'))
         l = a.len
         a.ror(1)
         self.assertTrue(a.startswith('0x800000'))
@@ -3649,7 +3664,7 @@ class Bugs(unittest.TestCase):
             s.byteswap(5.4)
 
     def testByteSwapFromFile(self):
-        s = BitStream(filename='smalltestfile')
+        s = BitStream(filename=os.path.join(THIS_DIR, 'smalltestfile'))
         swaps = s.byteswap('2bh')
         self.assertEqual(s, '0x0123674589abefcd')
         self.assertEqual(swaps, 2)
@@ -3864,16 +3879,18 @@ class ReadWithIntegers(unittest.TestCase):
 
 class FileReadingStrategy(unittest.TestCase):
     def testBitStreamIsAlwaysRead(self):
-        a = BitStream(filename='smalltestfile')
+        filename = os.path.join(THIS_DIR, 'smalltestfile')
+        a = BitStream(filename=filename)
         self.assertTrue(isinstance(a._datastore, bitstring.ByteStore))
-        with open('smalltestfile', 'rb') as f:
+        with open(filename, 'rb') as f:
             b = BitStream(f)
             self.assertTrue(isinstance(b._datastore, bitstring.ByteStore))
 
     def testBitsIsNeverRead(self):
-        a = ConstBitStream(filename='smalltestfile')
+        filename = os.path.join(THIS_DIR, 'smalltestfile')
+        a = ConstBitStream(filename=filename)
         self.assertTrue(isinstance(a._datastore._rawarray, bitstring.MmapByteArray))
-        with open('smalltestfile', 'rb') as f:
+        with open(filename, 'rb') as f:
             b = ConstBitStream(f)
             self.assertTrue(isinstance(b._datastore._rawarray, bitstring.MmapByteArray))
 

--- a/test/test_constbitstream.py
+++ b/test/test_constbitstream.py
@@ -5,11 +5,14 @@ import sys
 sys.path.insert(0, '..')
 import bitstring
 import io
+import os
 from bitstring import ConstBitStream as CBS
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class All(unittest.TestCase):
     def testFromFile(self):
-        s = CBS(filename='test.m1v')
+        s = CBS(filename=os.path.join(THIS_DIR, 'test.m1v'))
         self.assertEqual(s[0:32].hex, '000001b3')
         self.assertEqual(s.read(8 * 4).hex, '000001b3')
         width = s.read(12).uint
@@ -194,7 +197,8 @@ class CreationWithPos(unittest.TestCase):
         self.assertEqual(s.__repr__(), "ConstBitStream('0b110', pos=2)")
 
     def testStringRepresentationFromFile(self):
-        s = CBS(filename='test.m1v', pos=2001)
-        self.assertEqual(s.__repr__(), "ConstBitStream(filename='test.m1v', length=1002400, pos=2001)")
+        filename = os.path.join(THIS_DIR, 'test.m1v')
+        s = CBS(filename=filename, pos=2001)
+        self.assertEqual(s.__repr__(), f"ConstBitStream(filename='{filename}', length=1002400, pos=2001)")
         s.pos = 0
-        self.assertEqual(s.__repr__(), "ConstBitStream(filename='test.m1v', length=1002400)")
+        self.assertEqual(s.__repr__(), f"ConstBitStream(filename='{filename}', length=1002400)")


### PR DESCRIPTION
The [nixpkgs](https://github.com/NixOS/nixpkgs) package manager builds many Python projects and expects that projects using unittest can run the unittest command from the root dir.

The only changes that are needed to do this is to use absolute paths for files in tests relative to the current test file's path.


I hope that this is not too burdensome on maintenance for this project.