### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,25 @@ jobs:
         python:
           - name: CPython 3.7
             major_dot_minor: '3.7'
+            action: '3.7'
           - name: CPython 3.8
             major_dot_minor: '3.8'
+            action: '3.8'
           - name: CPython 3.9
             major_dot_minor: '3.9'
+            action: '3.9'
           - name: CPython 3.10
             major_dot_minor: '3.10'
+            action: '3.10'
           - name: CPython 3.11
             major_dot_minor: '3.11'
+            action: '3.11'
+          - name: PyPy 3.7
+            major_dot_minor: '3.7'
+            action: 'pypy-3.7'
+          - name: PyPy 3.8
+            major_dot_minor: '3.8'
+            action: 'pypy-3.8'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -55,7 +66,7 @@ jobs:
           #
           # CPython -> 3.9.0-alpha - 3.9.X
           # PyPy    -> pypy-3.7
-          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.action), matrix.python.action))[startsWith(matrix.python.action, 'pypy')] }}
           architecture: x64
       - name: Run unittest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,13 @@ jobs:
 
       - name: Setup environment
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install build
+          python -m venv venv
+          venv/bin/python -m pip install --upgrade pip
+          venv/bin/python -m pip install build
 
       - name: Build sdist and wheel
         run: |
-          python -m build
+          venv/bin/python -m build
 
       - name: Publish package files
         if: always()
@@ -128,17 +129,18 @@ jobs:
 
       - name: Setup environment
         run: |
-          python --version --version
+          python -m venv venv
+          venv/bin/python --version --version
           # make sure we test the installed code
           cp -R repo/tests/ .
-          python -m pip install --upgrade pip
-          python -m pip install ./dist/*.whl
+          venv/bin/python -m pip install --upgrade pip
+          venv/bin/python -m pip install ./dist/*.whl
           # make sure bitstring at least looks like what we want
-          python -c 'import bitstring; print(bitstring); assert bitstring.__file__.endswith("/site-packages/bitstring.py")'
+          venv/bin/python -c 'import bitstring; print(bitstring); assert bitstring.__file__.endswith("/site-packages/bitstring.py")'
 
       - name: Run unittest
         run: |
-          python -m unittest
+          venv/bin/python -m unittest
 
   all:
     name: All successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: lint_python
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
           architecture: x64
       - run: |
-        python -m unittest
+          python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,11 @@ jobs:
           cp -R repo/tests/ tests/
           python -m pip install --upgrade pip
           python -m pip install ./dist/*.whl
-          # make sure bitstring at least looks like what we want
-          python -c 'import bitstring; print(bitstring)'
+          # show the directory contents for diagnostics
+          ls -la
 
       - name: Run unittest
         run: |
-          ls -la
           python -m unittest
 
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,12 @@ jobs:
 
       - name: Setup environment
         run: |
-          python -m venv venv
-          venv/bin/python -m pip install --upgrade pip
-          venv/bin/python -m pip install build
+          python -m pip install --upgrade pip
+          python -m pip install build
 
       - name: Build sdist and wheel
         run: |
-          venv/bin/python -m build
+          python -m build
 
       - name: Publish package files
         if: always()
@@ -129,18 +128,18 @@ jobs:
 
       - name: Setup environment
         run: |
-          python -m venv venv
-          venv/bin/python --version --version
+          python --version --version
           # make sure we test the installed code
           cp -R repo/tests/ .
-          venv/bin/python -m pip install --upgrade pip
-          venv/bin/python -m pip install ./dist/*.whl
+          python -m pip install --upgrade pip
+          python -m pip install ./dist/*.whl
           # make sure bitstring at least looks like what we want
-          venv/bin/python -c 'import bitstring; print(bitstring); assert bitstring.__file__.endswith("/site-packages/bitstring.py")'
+          python -c 'import bitstring; print(bitstring)'
 
       - name: Run unittest
         run: |
-          venv/bin/python -m unittest
+          ls -la
+          python -m unittest
 
   all:
     name: All successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,20 @@ jobs:
           rm -rf bitstring/
           pip install --find-links dist/ bitstring
           python -m unittest
+
+  all:
+    name: All successful
+    runs-on: ubuntu-latest
+    # The always() part is very important.
+    # If not set, the job will be skipped on failing dependencies.
+    if: always()
+    needs:
+      # This is the list of CI job that we are interested to be green before
+      # a merge.
+      - build
+      - test
+    steps:
+      - name: Require all successes
+        uses: re-actors/alls-green@v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,48 @@ defaults:
     shell: bash
 
 jobs:
+  build:
+    name: Test ${{ matrix.os.name }} ${{ matrix.python.name }}
+    runs-on: ${{ matrix.os.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: 🐧
+            runs-on: ubuntu-latest
+        python:
+          - name: CPython 3.10
+            major_dot_minor: '3.10'
+            action: '3.10'
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          # This allows the matrix to specify just the major.minor version while still
+          # expanding it to get the latest patch version including alpha releases.
+          # This avoids the need to update for each new alpha, beta, release candidate,
+          # and then finally an actual release version.  actions/setup-python doesn't
+          # support this for PyPy presently so we get no help there.
+          #
+          # CPython -> 3.9.0-alpha - 3.9.X
+          # PyPy    -> pypy-3.7
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.action), matrix.python.action))[startsWith(matrix.python.action, 'pypy')] }}
+          architecture: x64
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: Publish package files
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*
+          if-no-files-found: error
+
   test:
     name: Test ${{ matrix.os.name }} ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on }}
@@ -56,6 +98,7 @@ jobs:
             action: 'pypy-3.8'
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-python@v4
         with:
           # This allows the matrix to specify just the major.minor version while still
@@ -68,6 +111,7 @@ jobs:
           # PyPy    -> pypy-3.7
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.action), matrix.python.action))[startsWith(matrix.python.action, 'pypy')] }}
           architecture: x64
+
       - name: Run unittest
         run: |
           python --version --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - '**'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     name: Test ${{ matrix.os.name }} ${{ matrix.python.name }}
@@ -50,4 +54,6 @@ jobs:
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
           architecture: x64
       - run: |
+          pwd
+          python --version --version
           python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ defaults:
 
 jobs:
   build:
-    name: Test ${{ matrix.os.name }} ${{ matrix.python.name }}
+    name: Build ${{ matrix.os.name }} ${{ matrix.python.name }}
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Download package files
         uses: actions/download-artifact@v3
         with:
-          name: dist
+          name: packages
           path: dist
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
           # make sure we test the installed code
           cp -R repo/tests/ .
           python -m pip install --upgrade pip
-          python -m pip install --find-links dist/ bitstring
+          python -m pip install ./dist/*.whl
 
       - name: Run unittest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,13 @@ jobs:
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.action), matrix.python.action))[startsWith(matrix.python.action, 'pypy')] }}
           architecture: x64
 
+      - name: Setup environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
       - name: Build sdist and wheel
         run: |
-          python -m pip install build
           python -m build
 
       - name: Publish package files
@@ -122,12 +126,16 @@ jobs:
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.action), matrix.python.action))[startsWith(matrix.python.action, 'pypy')] }}
           architecture: x64
 
-      - name: Run unittest
+      - name: Setup environment
         run: |
           python --version --version
           # make sure we test the installed code
           cp -R repo/tests/ .
-          pip install --find-links dist/ bitstring
+          python -m pip install --upgrade pip
+          python -m pip install --find-links dist/ bitstring
+
+      - name: Run unittest
+        run: |
           python -m unittest
 
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
 
   test:
     name: Test ${{ matrix.os.name }} ${{ matrix.python.name }}
+    needs:
+      - build
     runs-on: ${{ matrix.os.runs-on }}
     strategy:
       fail-fast: false
@@ -99,6 +101,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Download package files
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+
       - uses: actions/setup-python@v4
         with:
           # This allows the matrix to specify just the major.minor version while still
@@ -115,4 +123,7 @@ jobs:
       - name: Run unittest
         run: |
           python --version --version
+          # make sure we test the installed code
+          rm -rf bitstring/
+          pip install --find-links dist/ bitstring
           python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: lint_python
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    name: Test ${{ matrix.os.name }} ${{ matrix.python.name }}
+    runs-on: ${{ matrix.os.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - name: 🐧
+            runs-on: ubuntu-latest
+          - name: 🍎
+            runs-on: macos-latest
+          - name: 🪟
+            runs-on: windows-latest
+        python:
+          - name: CPython 3.7
+            major_dot_minor: '3.7'
+          - name: CPython 3.8
+            major_dot_minor: '3.8'
+          - name: CPython 3.9
+            major_dot_minor: '3.9'
+          - name: CPython 3.10
+            major_dot_minor: '3.10'
+          - name: CPython 3.11
+            major_dot_minor: '3.11'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          # This allows the matrix to specify just the major.minor version while still
+          # expanding it to get the latest patch version including alpha releases.
+          # This avoids the need to update for each new alpha, beta, release candidate,
+          # and then finally an actual release version.  actions/setup-python doesn't
+          # support this for PyPy presently so we get no help there.
+          #
+          # CPython -> 3.9.0-alpha - 3.9.X
+          # PyPy    -> pypy-3.7
+          python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
+          architecture: x64
+      - run: |
+        python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -53,7 +57,7 @@ jobs:
           # PyPy    -> pypy-3.7
           python-version: ${{ fromJSON(format('["{0}", "{1}"]', format('{0}.0-alpha - {0}.X', matrix.python.major_dot_minor), matrix.python.major_dot_minor))[startsWith(matrix.python.major_dot_minor, 'pypy')] }}
           architecture: x64
-      - run: |
-          pwd
+      - name: Run unittest
+        run: |
           python --version --version
           python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint_python
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
           cp -R repo/tests/ .
           python -m pip install --upgrade pip
           python -m pip install ./dist/*.whl
+          # make sure bitstring at least looks like what we want
+          python -c 'import bitstring; print(bitstring); assert bitstring.__file__.endswith("/site-packages/bitstring.py")'
 
       - name: Run unittest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           python --version --version
           # make sure we test the installed code
-          cp -R repo/tests/ .
+          cp -R repo/tests/ tests/
           python -m pip install --upgrade pip
           python -m pip install ./dist/*.whl
           # make sure bitstring at least looks like what we want

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
             action: 'pypy-3.8'
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: repo
 
       - name: Download package files
         uses: actions/download-artifact@v3
@@ -124,7 +126,7 @@ jobs:
         run: |
           python --version --version
           # make sure we test the installed code
-          rm -rf bitstring/
+          cp -R repo/tests/ .
           pip install --find-links dist/ bitstring
           python -m unittest
 

--- a/bitstring.py
+++ b/bitstring.py
@@ -1195,8 +1195,8 @@ class Bits:
             if self._datastore.byteoffset or self._offset:
                 offsetstring = ", offset=%d" % (self._datastore.rawarray.byteoffset * 8 + self._offset)
             lengthstring = ", length=%d" % length
-            return "{0}(filename='{1}'{2}{3}{4})".format(self.__class__.__name__,
-                                                         self._datastore.rawarray.source.name,
+            return "{0}(filename={1}{2}{3}{4})".format(self.__class__.__name__,
+                                                         repr(str(self._datastore.rawarray.source.name)),
                                                          lengthstring, offsetstring, pos_string)
         else:
             s = self.__str__()

--- a/tests/test_constbitstream.py
+++ b/tests/test_constbitstream.py
@@ -220,6 +220,6 @@ class CreationWithPos(unittest.TestCase):
     def testStringRepresentationFromFile(self):
         filename = os.path.join(THIS_DIR, 'test.m1v')
         s = CBS(filename=filename, pos=2001)
-        self.assertEqual(s.__repr__(), f"ConstBitStream(filename='{filename}', length=1002400, pos=2001)")
+        self.assertEqual(s.__repr__(), f"ConstBitStream(filename={repr(str(filename))}, length=1002400, pos=2001)")
         s.pos = 0
-        self.assertEqual(s.__repr__(), f"ConstBitStream(filename='{filename}', length=1002400)")
+        self.assertEqual(s.__repr__(), f"ConstBitStream(filename={repr(str(filename))}, length=1002400)")


### PR DESCRIPTION
Closes https://github.com/scott-griffiths/bitstring/issues/242.

Tests are run across Linux/macOS/Windows, CPython 3.7-3.11, and PyPy 3.7-3.8.  First, the wheel and sdist are built and uploaded as workflow artifacts.  These can be downloaded from the run summary page.  These artifacts are then downloaded, installed, and tested on each platform.  The checked out source directory `bitstring/` is deleted to make sure we test the package files themselves.  When making a release, these files can be uploaded to PyPI knowing that exactly those files were tested across the whole matrix.  Well, I don't test both sdist and wheel separately, but...  If you want an auto-upload-on-tag or such addition, we can certainly add that as well.  Finally, the `All successful` job only passes if all other jobs have actually succeeded.  This works around some GitHub Actions behavior where skipped jobs aren't considered failures but can happen where you as a user might consider them failures.  This job can then be added as the single required check in the project branch protection settings instead of having to select every individual job in the matrix and keep the settings updated as the matrix adds and removes elements.