### PR TITLE
Make the build reproducible

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,8 +1,14 @@
 # Configuration file for the Sphinx documentation builder.
 #
+import os
+import time
 import datetime
 
-year = datetime.datetime.now().year
+import datetime
+
+year = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+).year
 
 project = 'bitstring'
 copyright = f'2006 - {year}, Scott Griffiths'


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort in Debian, I noticed that bitstring could not be built reproducibly.

This was because the documentation used the build year in the documentation:

```
│ │ │ ├── ./usr/share/doc/python-bitstring-doc/html/bitarray.html
│ │ │ │ @@ -973,11 +973,11 @@
│ │ │ │               >previous</a> |</li>
│ │ │ │          <li class="nav-item nav-item-0"><a href="index.html">bitstring 4.0 documentation</a> &#187;</li>
│ │ │ │            <li class="nav-item nav-item-1"><a href="reference.html" >Reference</a> &#187;</li>
│ │ │ │          <li class="nav-item nav-item-this"><a href="">BitArray Class</a></li>
│ │ │ │        </ul>
│ │ │ │      </div>
│ │ │ │      <div class="footer" role="contentinfo">
│ │ │ │ -        &#169; Copyright 2023 - 2023, Scott Griffiths.
│ │ │ │ +        &#169; Copyright 2023 - 2024, Scott Griffiths.
│ │ │ │      </div>
│ │ │ │    </body>
│ │ │ │  </html>
```

This patch bases this value on the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) environment variable (if available). I originally filed this in Debian as bug [#1039932](https://bugs.debian.org/1039932).
