### PR TITLE
Update bitarray dependency

### DIFF
--- a/bitstring/bitstore.py
+++ b/bitstring/bitstore.py
@@ -159,7 +159,7 @@ class BitStore:
                 byte_pos = byte_pos + 1
             return
         # General case
-        i = self._bitarray.itersearch(bs._bitarray, start, end)
+        i = self._bitarray.search(bs._bitarray, start, end)
         if not bytealigned:
             for p in i:
                 yield p
@@ -169,7 +169,7 @@ class BitStore:
                     yield p
 
     def rfindall_msb0(self, bs: BitStore, start: int, end: int, bytealigned: bool = False) -> Iterator[int]:
-        i = self._bitarray.itersearch(bs._bitarray, start, end, right=True)
+        i = self._bitarray.search(bs._bitarray, start, end, right=True)
         if not bytealigned:
             for p in i:
                 yield p

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 keywords = ["binary", "bitarray", "bitvector", "bitfield"]
 dependencies = [
-  "bitarray >= 2.9.0, < 3.0.0",
+  "bitarray >= 2.9.0, < 4"
 ]
 
 [project.urls]


### PR DESCRIPTION
I noticed that the bitarray dependency could be updated with only minor changes as per [Bitarray 3 transition](https://github.com/ilanschnell/bitarray/blob/master/doc/bitarray3.rst). Note that with an unchanged lower bound this makes the API exported via Bits.tobitarray() implicitly dependent on the user's installed version of bitarray. With the changes, tests pass with either of bitarray 2.9.3 or 3.0.0 installed, so bitstring itself appears agnostic. The lower bound could be raised to 3.0.0 with the effect of fixing the exported bitarray API, but I don't know whether that's an issue for anyone downstream. (For me, bitstring is only a dependency of angr via PyVEX, and I don't immediately see any consequences from updating bitarray.) Thanks for the package!