### PR TITLE
pyupgrade 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,6 @@ jobs:
           - name: 🪟
             runs-on: windows-latest
         python:
-          - name: CPython 3.8
-            major_dot_minor: '3.8'
-            action: '3.8'
           - name: CPython 3.9
             major_dot_minor: '3.9'
             action: '3.9'

--- a/bitstring/__init__.py
+++ b/bitstring/__init__.py
@@ -140,7 +140,7 @@ def uint_bits2chars(bitlength: int):
 
 def int_bits2chars(bitlength: int):
     # How many characters is largest negative int of this length? (To include minus sign).
-    return len(str((-1 << (bitlength - 1))))
+    return len(str(-1 << (bitlength - 1)))
 
 
 def float_bits2chars(bitlength: Literal[16, 32, 64]):

--- a/bitstring/__init__.py
+++ b/bitstring/__init__.py
@@ -70,7 +70,7 @@ from .array_ import Array
 from .exceptions import Error, ReadError, InterpretError, ByteAlignError, CreationError
 from .dtypes import DtypeDefinition, dtype_register, Dtype
 import types
-from typing import List, Tuple, Literal
+from typing import Literal
 from .mxfp import decompress_luts as mxfp_decompress_luts
 from .fp8 import decompress_luts as binary8_decompress_luts
 
@@ -281,7 +281,7 @@ dtype_definitions = [
 ]
 
 
-aliases: List[Tuple[str, str]] = [
+aliases: list[tuple[str, str]] = [
     # Floats default to big endian
     ('float', 'floatbe'),
     ('bfloat', 'bfloatbe'),

--- a/bitstring/array_.py
+++ b/bitstring/array_.py
@@ -4,7 +4,8 @@ import math
 import numbers
 from collections.abc import Sized
 from bitstring.exceptions import CreationError
-from typing import Union, List, Iterable, Any, Optional, BinaryIO, overload, TextIO
+from typing import Union, Any, Optional, BinaryIO, overload, TextIO
+from collections.abc import Iterable
 from bitstring.bits import Bits, BitsType
 from bitstring.bitarray_ import BitArray
 from bitstring.dtypes import Dtype, dtype_register
@@ -273,7 +274,7 @@ class Array:
         new_array = self.__class__(dtype, self.tolist())
         return new_array
 
-    def tolist(self) -> List[ElementType]:
+    def tolist(self) -> list[ElementType]:
         return [self._dtype.read_fn(self.data, start=start)
                 for start in range(0, len(self.data) - self._dtype.length + 1, self._dtype.length)]
 

--- a/bitstring/bitarray_.py
+++ b/bitstring/bitarray_.py
@@ -4,7 +4,8 @@ import copy
 import numbers
 import re
 from collections import abc
-from typing import Union, List, Iterable, Any, Optional
+from typing import Union, Any, Optional
+from collections.abc import Iterable
 from bitstring import utils
 from bitstring.exceptions import CreationError, Error
 from bitstring.bits import Bits, BitsType, TBits
@@ -272,7 +273,7 @@ class BitArray(Bits):
         if bytealigned is None:
             bytealigned = bitstring.options.bytealigned
         # First find all the places where we want to do the replacements
-        starting_points: List[int] = []
+        starting_points: list[int] = []
         for x in self.findall(old, start, end, bytealigned=bytealigned):
             if not starting_points:
                 starting_points.append(x)

--- a/bitstring/bits.py
+++ b/bitstring/bits.py
@@ -9,7 +9,8 @@ import array
 import io
 from collections import abc
 import functools
-from typing import Tuple, Union, List, Iterable, Any, Optional, BinaryIO, TextIO, overload, Iterator, Type, TypeVar
+from typing import Union, Any, Optional, BinaryIO, TextIO, overload, Type, TypeVar
+from collections.abc import Iterable, Iterator
 import bitarray
 import bitarray.util
 import bitstring
@@ -110,7 +111,7 @@ class Bits:
         """
         self._bitstore.immutable = True
 
-    def __new__(cls: Type[TBits], auto: Optional[Union[BitsType, int]] = None, /, length: Optional[int] = None,
+    def __new__(cls: type[TBits], auto: Optional[Union[BitsType, int]] = None, /, length: Optional[int] = None,
                 offset: Optional[int] = None, pos: Optional[int] = None, **kwargs) -> TBits:
         x = super().__new__(cls)
         if auto is None and not kwargs:
@@ -125,7 +126,7 @@ class Bits:
         return x
 
     @classmethod
-    def _create_from_bitstype(cls: Type[TBits], auto: BitsType, /) -> TBits:
+    def _create_from_bitstype(cls: type[TBits], auto: BitsType, /) -> TBits:
         if isinstance(auto, cls):
             return auto
         b = super().__new__(cls)
@@ -606,7 +607,7 @@ class Bits:
     def _setmxint(self, f: float) -> None:
         self._bitstore = bitstore_helpers.mxint2bitstore(f)
 
-    def _setbytes(self, data: Union[bytearray, bytes, List], length:None = None) -> None:
+    def _setbytes(self, data: Union[bytearray, bytes, list], length:None = None) -> None:
         """Set the data from a bytes or bytearray object."""
         self._bitstore = BitStore.frombytes(bytes(data))
 
@@ -816,7 +817,7 @@ class Bits:
             raise bitstring.CreationError("Exp-Golomb codes cannot be used in lsb0 mode.")
         self._bitstore = bitstore_helpers.ue2bitstore(i)
 
-    def _readue(self, pos: int) -> Tuple[int, int]:
+    def _readue(self, pos: int) -> tuple[int, int]:
         """Return interpretation of next bits as unsigned exponential-Golomb code.
 
         Raises ReadError if the end of the bitstring is encountered while
@@ -843,25 +844,25 @@ class Bits:
             pos += 1
         return codenum, pos
 
-    def _getue(self) -> Tuple[int, int]:
+    def _getue(self) -> tuple[int, int]:
         try:
             return self._readue(0)
         except bitstring.ReadError:
             raise bitstring.InterpretError
 
-    def _getse(self) -> Tuple[int, int]:
+    def _getse(self) -> tuple[int, int]:
         try:
             return self._readse(0)
         except bitstring.ReadError:
             raise bitstring.InterpretError
 
-    def _getuie(self) -> Tuple[int, int]:
+    def _getuie(self) -> tuple[int, int]:
         try:
             return self._readuie(0)
         except bitstring.ReadError:
             raise bitstring.InterpretError
 
-    def _getsie(self) -> Tuple[int, int]:
+    def _getsie(self) -> tuple[int, int]:
         try:
             return self._readsie(0)
         except bitstring.ReadError:
@@ -873,7 +874,7 @@ class Bits:
             raise bitstring.CreationError("Exp-Golomb codes cannot be used in lsb0 mode.")
         self._bitstore = bitstore_helpers.se2bitstore(i)
 
-    def _readse(self, pos: int) -> Tuple[int, int]:
+    def _readse(self, pos: int) -> tuple[int, int]:
         """Return interpretation of next bits as a signed exponential-Golomb code.
 
         Advances position to after the read code.
@@ -896,7 +897,7 @@ class Bits:
             raise bitstring.CreationError("Exp-Golomb codes cannot be used in lsb0 mode.")
         self._bitstore = bitstore_helpers.uie2bitstore(i)
 
-    def _readuie(self, pos: int) -> Tuple[int, int]:
+    def _readuie(self, pos: int) -> tuple[int, int]:
         """Return interpretation of next bits as unsigned interleaved exponential-Golomb code.
 
         Raises ReadError if the end of the bitstring is encountered while
@@ -923,7 +924,7 @@ class Bits:
             raise bitstring.CreationError("Exp-Golomb codes cannot be used in lsb0 mode.")
         self._bitstore = bitstore_helpers.sie2bitstore(i)
 
-    def _readsie(self, pos: int) -> Tuple[int, int]:
+    def _readsie(self, pos: int) -> tuple[int, int]:
         """Return interpretation of next bits as a signed interleaved exponential-Golomb code.
 
         Advances position to after the read code.
@@ -1018,7 +1019,7 @@ class Bits:
         bs._bitstore = self._bitstore.getslice_msb0(start, end)
         return bs
 
-    def _readtoken(self, name: str, pos: int, length: Optional[int]) -> Tuple[Union[float, int, str, None, Bits], int]:
+    def _readtoken(self, name: str, pos: int, length: Optional[int]) -> tuple[Union[float, int, str, None, Bits], int]:
         """Reads a token from the bitstring and returns the result."""
         dtype = dtype_register.get_dtype(name, length)
         if dtype.bitlength is not None and dtype.bitlength > len(self) - pos:
@@ -1136,7 +1137,7 @@ class Bits:
     def _getbits(self: TBits):
         return self._copy()
 
-    def _validate_slice(self, start: Optional[int], end: Optional[int]) -> Tuple[int, int]:
+    def _validate_slice(self, start: Optional[int], end: Optional[int]) -> tuple[int, int]:
         """Validate start and end and return them as positive bit positions."""
         start = 0 if start is None else (start + len(self) if start < 0 else start)
         end = len(self) if end is None else (end + len(self) if end < 0 else end)
@@ -1144,7 +1145,7 @@ class Bits:
             raise ValueError(f"Invalid slice positions for bitstring length {len(self)}: start={start}, end={end}.")
         return start, end
 
-    def unpack(self, fmt: Union[str, List[Union[str, int]]], **kwargs) -> List[Union[int, float, str, Bits, bool, bytes, None]]:
+    def unpack(self, fmt: Union[str, list[Union[str, int]]], **kwargs) -> list[Union[int, float, str, Bits, bool, bytes, None]]:
         """Interpret the whole bitstring using fmt and return list.
 
         fmt -- A single string or a list of strings with comma separated tokens
@@ -1161,8 +1162,8 @@ class Bits:
         """
         return self._readlist(fmt, 0, **kwargs)[0]
 
-    def _readlist(self, fmt: Union[str, List[Union[str, int, Dtype]]], pos: int, **kwargs) \
-            -> Tuple[List[Union[int, float, str, Bits, bool, bytes, None]], int]:
+    def _readlist(self, fmt: Union[str, list[Union[str, int, Dtype]]], pos: int, **kwargs) \
+            -> tuple[list[Union[int, float, str, Bits, bool, bytes, None]], int]:
         if isinstance(fmt, str):
             fmt = [fmt]
         # Convert to a flat list of Dtypes
@@ -1183,7 +1184,7 @@ class Bits:
                         dtype_list.append(Dtype(name, length))
         return self._read_dtype_list(dtype_list, pos)
 
-    def _read_dtype_list(self, dtypes: List[Dtype], pos: int) -> Tuple[List[Union[int, float, str, Bits, bool, bytes, None]], int]:
+    def _read_dtype_list(self, dtypes: list[Dtype], pos: int) -> tuple[list[Union[int, float, str, Bits, bool, bytes, None]], int]:
         has_stretchy_token = False
         bits_after_stretchy_token = 0
         for dtype in dtypes:
@@ -1221,7 +1222,7 @@ class Bits:
         return vals, pos
 
     def find(self, bs: BitsType, /, start: Optional[int] = None, end: Optional[int] = None,
-             bytealigned: Optional[bool] = None) -> Union[Tuple[int], Tuple[()]]:
+             bytealigned: Optional[bool] = None) -> Union[tuple[int], tuple[()]]:
         """Find first occurrence of substring bs.
 
         Returns a single item tuple with the bit position if found, or an
@@ -1250,7 +1251,7 @@ class Bits:
         p = self._find(bs, start, end, ba)
         return p
 
-    def _find_lsb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[Tuple[int], Tuple[()]]:
+    def _find_lsb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[tuple[int], tuple[()]]:
         # A forward find in lsb0 is very like a reverse find in msb0.
         assert start <= end
         assert bitstring.options.lsb0
@@ -1264,7 +1265,7 @@ class Bits:
         else:
             return ()
 
-    def _find_msb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[Tuple[int], Tuple[()]]:
+    def _find_msb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[tuple[int], tuple[()]]:
         """Find first occurrence of a binary string."""
         p = self._bitstore.find(bs._bitstore, start, end, bytealigned)
         return () if p == -1 else (p,)
@@ -1337,7 +1338,7 @@ class Bits:
                 return
 
     def rfind(self, bs: BitsType, /, start: Optional[int] = None, end: Optional[int] = None,
-              bytealigned: Optional[bool] = None) -> Union[Tuple[int], Tuple[()]]:
+              bytealigned: Optional[bool] = None) -> Union[tuple[int], tuple[()]]:
         """Find final occurrence of substring bs.
 
         Returns a single item tuple with the bit position if found, or an
@@ -1363,12 +1364,12 @@ class Bits:
         p = self._rfind(bs, start, end, ba)
         return p
 
-    def _rfind_msb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[Tuple[int], Tuple[()]]:
+    def _rfind_msb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[tuple[int], tuple[()]]:
         """Find final occurrence of a binary string."""
         p = self._bitstore.rfind(bs._bitstore, start, end, bytealigned)
         return () if p == -1 else (p,)
 
-    def _rfind_lsb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[Tuple[int], Tuple[()]]:
+    def _rfind_lsb0(self, bs: Bits, start: int, end: int, bytealigned: bool) -> Union[tuple[int], tuple[()]]:
         # A reverse find in lsb0 is very like a forward find in msb0.
         assert start <= end
         assert bitstring.options.lsb0
@@ -1584,7 +1585,7 @@ class Bits:
 
     @staticmethod
     def _format_bits(bits: Bits, bits_per_group: int, sep: str, dtype: Dtype,
-                     colour_start: str, colour_end: str, width: Optional[int]=None) -> Tuple[str, int]:
+                     colour_start: str, colour_end: str, width: Optional[int]=None) -> tuple[str, int]:
         get_fn = dtype.get_fn
         if dtype.name == 'bytes':  # Special case for bytes to print one character each.
             get_fn = Bits._getbytes_printable

--- a/bitstring/bitstore.py
+++ b/bitstring/bitstore.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import bitarray
 from bitstring.exceptions import CreationError
-from typing import Union, Iterable, Optional, overload, Iterator, Any
+from typing import Union, Optional, overload, Any
+from collections.abc import Iterable, Iterator
 
 
 def offset_slice_indices_lsb0(key: slice, length: int) -> slice:

--- a/bitstring/bitstore_helpers.py
+++ b/bitstring/bitstore_helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import struct
 import math
 import functools
-from typing import Union, Optional, Dict, Callable
+from typing import Union, Optional, Callable
 import bitarray
 from bitstring.bitstore import BitStore
 import bitstring
@@ -244,7 +244,7 @@ def float2bitstore(f: Union[str, float], length: int, big_endian: bool) -> BitSt
     return BitStore.frombytes(b)
 
 
-literal_bit_funcs: Dict[str, Callable[..., BitStore]] = {
+literal_bit_funcs: dict[str, Callable[..., BitStore]] = {
     '0x': hex2bitstore,
     '0X': hex2bitstore,
     '0b': bin2bitstore,

--- a/bitstring/bitstream.py
+++ b/bitstring/bitstream.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import bitstring
 from bitstring.bits import Bits, BitsType
 from bitstring.dtypes import Dtype
-from typing import Union, List, Any, Optional, overload, TypeVar, Tuple
+from typing import Union, Any, Optional, overload, TypeVar
 import copy
 import numbers
 
@@ -231,7 +231,7 @@ class ConstBitStream(Bits):
         self._pos = pos + len(bs)
 
     def find(self, bs: BitsType, /, start: Optional[int] = None, end: Optional[int] = None,
-             bytealigned: Optional[bool] = None) -> Union[Tuple[int], Tuple[()]]:
+             bytealigned: Optional[bool] = None) -> Union[tuple[int], tuple[()]]:
         """Find first occurrence of substring bs.
 
         Returns a single item tuple with the bit position if found, or an
@@ -259,7 +259,7 @@ class ConstBitStream(Bits):
         return p
 
     def rfind(self, bs: BitsType, /, start: Optional[int] = None, end: Optional[int] = None,
-              bytealigned: Optional[bool] = None) -> Union[Tuple[int], Tuple[()]]:
+              bytealigned: Optional[bool] = None) -> Union[tuple[int], tuple[()]]:
         """Find final occurrence of substring bs.
 
         Returns a single item tuple with the bit position if found, or an
@@ -356,8 +356,8 @@ class ConstBitStream(Bits):
             raise bitstring.ReadError(f"Reading off end of bitstring with fmt '{fmt}'. Only {len(self) - p} bits available.")
         return val
 
-    def readlist(self, fmt: Union[str, List[Union[int, str, Dtype]]], **kwargs) \
-            -> List[Union[int, float, str, Bits, bool, bytes, None]]:
+    def readlist(self, fmt: Union[str, list[Union[int, str, Dtype]]], **kwargs) \
+            -> list[Union[int, float, str, Bits, bool, bytes, None]]:
         """Interpret next bits according to format string(s) and return list.
 
         fmt -- A single string or list of strings with comma separated tokens
@@ -429,8 +429,8 @@ class ConstBitStream(Bits):
         self._pos = pos_before
         return value
 
-    def peeklist(self, fmt: Union[str, List[Union[int, str]]], **kwargs) \
-            -> List[Union[int, float, str, Bits, None]]:
+    def peeklist(self, fmt: Union[str, list[Union[int, str]]], **kwargs) \
+            -> list[Union[int, float, str, Bits, None]]:
         """Interpret next bits according to format string(s) and return list.
 
         fmt -- One or more integers or strings with comma separated tokens describing

--- a/bitstring/bitstring_options.py
+++ b/bitstring/bitstring_options.py
@@ -78,7 +78,7 @@ class Options:
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(Options, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance
 
 

--- a/bitstring/dtypes.py
+++ b/bitstring/dtypes.py
@@ -351,7 +351,7 @@ class Register:
     def __new__(cls) -> Register:
         # Singleton. Only one Register instance can ever exist.
         if cls._instance is None:
-            cls._instance = super(Register, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance
 
     @classmethod

--- a/bitstring/dtypes.py
+++ b/bitstring/dtypes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Optional, Dict, Any, Union, Tuple, Callable
+from typing import Optional, Any, Union, Callable
 import inspect
 import bitstring
 from bitstring import utils
@@ -222,7 +222,7 @@ class Dtype:
 
 
 class AllowedLengths:
-    def __init__(self, value: Tuple[int, ...] = tuple()) -> None:
+    def __init__(self, value: tuple[int, ...] = tuple()) -> None:
         if len(value) >= 3 and value[-1] is Ellipsis:
             step = value[1] - value[0]
             for i in range(1, len(value) - 1):
@@ -253,7 +253,7 @@ class DtypeDefinition:
     Not (yet) part of the public interface."""
 
     def __init__(self, name: str, set_fn, get_fn, return_type: Any = Any, is_signed: bool = False, bitlength2chars_fn=None,
-                 variable_length: bool = False, allowed_lengths: Tuple[int, ...] = tuple(), multiplier: int = 1, description: str = ''):
+                 variable_length: bool = False, allowed_lengths: tuple[int, ...] = tuple(), multiplier: int = 1, description: str = ''):
 
         # Consistency checks
         if int(multiplier) != multiplier or multiplier <= 0:
@@ -346,7 +346,7 @@ class Register:
     """A singleton class that holds all the DtypeDefinitions. Not (yet) part of the public interface."""
 
     _instance: Optional[Register] = None
-    names: Dict[str, DtypeDefinition] = {}
+    names: dict[str, DtypeDefinition] = {}
 
     def __new__(cls) -> Register:
         # Singleton. Only one Register instance can ever exist.

--- a/bitstring/exceptions.py
+++ b/bitstring/exceptions.py
@@ -1,4 +1,3 @@
-
 class Error(Exception):
     """Base class for errors in the bitstring module."""
 

--- a/bitstring/methods.py
+++ b/bitstring/methods.py
@@ -4,12 +4,12 @@ import bitstring
 from bitstring.bitstream import BitStream
 from bitstring.utils import tokenparser
 from bitstring.exceptions import CreationError
-from typing import Union, List
+from typing import Union
 from bitstring.bitstore import BitStore
 from bitstring.bitstore_helpers import bitstore_from_token
 
 
-def pack(fmt: Union[str, List[str]], *values, **kwargs) -> BitStream:
+def pack(fmt: Union[str, list[str]], *values, **kwargs) -> BitStream:
     """Pack the values according to the format string and return a new BitStream.
 
     fmt -- A single string or a list of strings with comma separated tokens
@@ -54,7 +54,7 @@ def pack(fmt: Union[str, List[str]], *values, **kwargs) -> BitStream:
     except ValueError as e:
         raise CreationError(*e.args)
     value_iter = iter(values)
-    bsl: List[BitStore] = []
+    bsl: list[BitStore] = []
     try:
         for name, length, value in tokens:
             # If the value is in the kwd dictionary then it takes precedence.

--- a/bitstring/utils.py
+++ b/bitstring/utils.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import functools
 import re
-from typing import Tuple, List, Optional, Pattern, Dict, Union, Match
+from typing import Optional, Union
+from re import Pattern, Match
 
 
 # A token name followed by optional : then an integer number
@@ -32,31 +33,31 @@ STRUCT_SPLIT_RE: Pattern[str] = re.compile(r'\d*[bBhHlLqQefd]')
 
 # These replicate the struct.pack codes
 # Big-endian
-REPLACEMENTS_BE: Dict[str, str] = {'b': 'int8', 'B': 'uint8',
+REPLACEMENTS_BE: dict[str, str] = {'b': 'int8', 'B': 'uint8',
                                    'h': 'intbe16', 'H': 'uintbe16',
                                    'l': 'intbe32', 'L': 'uintbe32',
                                    'q': 'intbe64', 'Q': 'uintbe64',
                                    'e': 'floatbe16', 'f': 'floatbe32', 'd': 'floatbe64'}
 # Little-endian
-REPLACEMENTS_LE: Dict[str, str] = {'b': 'int8', 'B': 'uint8',
+REPLACEMENTS_LE: dict[str, str] = {'b': 'int8', 'B': 'uint8',
                                    'h': 'intle16', 'H': 'uintle16',
                                    'l': 'intle32', 'L': 'uintle32',
                                    'q': 'intle64', 'Q': 'uintle64',
                                    'e': 'floatle16', 'f': 'floatle32', 'd': 'floatle64'}
 
 # Native-endian
-REPLACEMENTS_NE: Dict[str, str] = {'b': 'int8', 'B': 'uint8',
+REPLACEMENTS_NE: dict[str, str] = {'b': 'int8', 'B': 'uint8',
                                    'h': 'intne16', 'H': 'uintne16',
                                    'l': 'intne32', 'L': 'uintne32',
                                    'q': 'intne64', 'Q': 'uintne64',
                                    'e': 'floatne16', 'f': 'floatne32', 'd': 'floatne64'}
 
 # Size in bytes of all the pack codes.
-PACK_CODE_SIZE: Dict[str, int] = {'b': 1, 'B': 1, 'h': 2, 'H': 2, 'l': 4, 'L': 4,
+PACK_CODE_SIZE: dict[str, int] = {'b': 1, 'B': 1, 'h': 2, 'H': 2, 'l': 4, 'L': 4,
                                   'q': 8, 'Q': 8, 'e': 2, 'f': 4, 'd': 8}
 
 
-def structparser(m: Match[str]) -> List[str]:
+def structparser(m: Match[str]) -> list[str]:
     """Parse struct-like format string token into sub-token list."""
     endian = m.group('endian')
     # Split the format string into a list of 'q', '4h' etc.
@@ -76,7 +77,7 @@ def structparser(m: Match[str]) -> List[str]:
 
 
 @functools.lru_cache(CACHE_SIZE)
-def parse_name_length_token(fmt: str, **kwargs) -> Tuple[str, Optional[int]]:
+def parse_name_length_token(fmt: str, **kwargs) -> tuple[str, Optional[int]]:
     # Any single token with just a name and length
     if m2 := NAME_INT_RE.match(fmt):
         name = m2.group(1)
@@ -97,7 +98,7 @@ def parse_name_length_token(fmt: str, **kwargs) -> Tuple[str, Optional[int]]:
 
 
 @functools.lru_cache(CACHE_SIZE)
-def parse_single_struct_token(fmt: str) -> Optional[Tuple[str, Optional[int]]]:
+def parse_single_struct_token(fmt: str) -> Optional[tuple[str, Optional[int]]]:
     if m := SINGLE_STRUCT_PACK_RE.match(fmt):
         endian = m.group('endian')
         f = m.group('fmt')
@@ -114,7 +115,7 @@ def parse_single_struct_token(fmt: str) -> Optional[Tuple[str, Optional[int]]]:
 
 
 @functools.lru_cache(CACHE_SIZE)
-def parse_single_token(token: str) -> Tuple[str, str, Optional[str]]:
+def parse_single_token(token: str) -> tuple[str, str, Optional[str]]:
     if (equals_pos := token.find('=')) == -1:
         value = None
     else:
@@ -137,7 +138,7 @@ def parse_single_token(token: str) -> Tuple[str, str, Optional[str]]:
 
 
 @functools.lru_cache(CACHE_SIZE)
-def preprocess_tokens(fmt: str) -> List[str]:
+def preprocess_tokens(fmt: str) -> list[str]:
     # Remove whitespace and expand brackets
     fmt = expand_brackets(''.join(fmt.split()))
 
@@ -164,8 +165,8 @@ def preprocess_tokens(fmt: str) -> List[str]:
 
 
 @functools.lru_cache(CACHE_SIZE)
-def tokenparser(fmt: str, keys: Tuple[str, ...] = ()) -> \
-        Tuple[bool, List[Tuple[str, Union[int, str, None], Optional[str]]]]:
+def tokenparser(fmt: str, keys: tuple[str, ...] = ()) -> \
+        tuple[bool, list[tuple[str, Union[int, str, None], Optional[str]]]]:
     """Divide the format string into tokens and parse them.
 
     Return stretchy token and list of [initialiser, length, value]
@@ -180,7 +181,7 @@ def tokenparser(fmt: str, keys: Tuple[str, ...] = ()) -> \
     """
     tokens = preprocess_tokens(fmt)
     stretchy_token = False
-    ret_vals: List[Tuple[str, Union[str, int, None], Optional[str]]] = []
+    ret_vals: list[tuple[str, Union[str, int, None], Optional[str]]] = []
     for token in tokens:
         if keys and token in keys:
             # Don't bother parsing it, it's a keyword argument

--- a/doc/array.rst
+++ b/doc/array.rst
@@ -331,7 +331,7 @@ Methods
 
     Write Array data to a file, padding with zero bits at the end if needed.
 
-.. method:: Array.tolist() -> List[float | int | str | bytes]
+.. method:: Array.tolist() -> list[float | int | str | bytes]
 
     Return Array items as a list.
 

--- a/doc/bits.rst
+++ b/doc/bits.rst
@@ -122,7 +122,7 @@ Methods
         False
 
 
-.. method:: Bits.find(bs: BitsType, start: int | None = None, end: int | None = None, bytealigned: bool | None = None) -> Tuple[int] | Tuple[()]
+.. method:: Bits.find(bs: BitsType, start: int | None = None, end: int | None = None, bytealigned: bool | None = None) -> tuple[int] | tuple[()]
 
     Searches for *bs* in the current bitstring and sets :attr:`~ConstBitStream.pos` to the start of *bs* and returns it in a tuple if found, otherwise it returns an empty tuple.
 
@@ -212,7 +212,7 @@ Methods
     By default the output will have colours added in the terminal. This can be disabled - see :data:`bitstring.options.no_color` for more information.
 
 
-.. method:: Bits.rfind(bs: BitsType, start: int | None = None, end: int | None = None, bytealigned: bool | None = None) -> Tuple[int] | Tuple[()]
+.. method:: Bits.rfind(bs: BitsType, start: int | None = None, end: int | None = None, bytealigned: bool | None = None) -> tuple[int] | tuple[()]
 
     Searches backwards for *bs* in the current bitstring and sets :attr:`~ConstBitStream.pos` to the start of *bs* and returns it in a tuple if found, otherwise it returns an empty tuple.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,12 @@ authors = [
 ]
 description = "Simple construction, analysis and modification of binary data."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tests/test_bitarray.py
+++ b/tests/test_bitarray.py
@@ -306,7 +306,7 @@ class TestSliceAssignment:
         with pytest.raises(ValueError):
             a[::3] = [1]
 
-        class A(object):
+        class A:
             pass
         with pytest.raises(TypeError):
             a[1:2] = A()

--- a/tests/test_bitstream.py
+++ b/tests/test_bitstream.py
@@ -1551,7 +1551,7 @@ class TestAdding:
         s6 = BitStream('0b111')
         assert s5 == s6
 
-        class A(object):
+        class A:
             pass
         assert not s5 == A()
 
@@ -3730,14 +3730,14 @@ class TestBugs:
             assert le.len == be.len
 
     def test_unicode(self):
-        a = ConstBitStream(u'uint:12=34')
+        a = ConstBitStream('uint:12=34')
         assert a.uint == 34
-        a += u'0xfe'
+        a += '0xfe'
         assert a[12:] == '0xfe'
         a = BitStream('0x1122')
-        c = a.byteswap(u'h')
+        c = a.byteswap('h')
         assert c == 1
-        assert a == u'0x2211'
+        assert a == '0x2211'
 
 
 class TestUnpackWithDict:

--- a/tests/test_bitstring.py
+++ b/tests/test_bitstring.py
@@ -28,7 +28,7 @@ class TestModuleData:
     def test_pyproject_version(self):
         filename = os.path.join(THIS_DIR, '../pyproject.toml')
         try:
-            with open(filename, 'r') as pyprojectfile:
+            with open(filename) as pyprojectfile:
                 found = False
                 for line in pyprojectfile.readlines():
                     if line.startswith("version"):

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,4 +1,3 @@
-
 import pytest
 import sys
 import bitstring as bs

--- a/tests/test_mxfp.py
+++ b/tests/test_mxfp.py
@@ -171,7 +171,7 @@ def test_setting_scaled_array():
     assert sa[:] == [0.0, 1.0, 2.0]
 
 def test_multiple_scaled_arrays():
-    d = bytes(b'hello_everyone!')
+    d = b'hello_everyone!'
     s1 = Array(Dtype('e2m1mxfp', scale=1), d)
     s2 = Array(Dtype('e2m1mxfp', scale=2**10), d)
     s3 = Array(Dtype('e2m1mxfp', scale=2**-10), d)


### PR DESCRIPTION
Drop support for [3.8 since it's EOL](https://peps.python.org/pep-0569/) and apply `pyupgrade` up to 3.9