### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "bitstring"
 version = "4.3.1"
+license = { text = "MIT" }
 authors = [
   { name="Scott Griffiths", email="dr.scottgriffiths@gmail.com" },
 ]


### PR DESCRIPTION
Setuptools `v77` added support for PEP 639 license expression. However, that only supports Python `>=3.9`. Until support for `3.8` is dropped, the legacy `license.text` field could be used together with the SPDX license identifier.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files