### PR TITLE
Fix BitStream pos not reset to 0 when content replaced via dtype setter

### DIFF
--- a/bitstring/bitstream.py
+++ b/bitstring/bitstream.py
@@ -623,6 +623,13 @@ class BitStream(ConstBitStream, bitstring.BitArray):
         s_copy._bitstore = self._bitstore.copy()
         return s_copy
 
+    def __setattr__(self, attribute: str, value) -> None:
+        bitstore_id_before = id(self._bitstore) if hasattr(self, '_bitstore') else None
+        super().__setattr__(attribute, value)
+        # If a dtype property setter replaced the bitstore, reset the bit position.
+        if bitstore_id_before is not None and id(self._bitstore) != bitstore_id_before:
+            self._pos = 0
+
     def __iadd__(self, bs: BitsType, /) -> BitStream:
         """Append to current bitstring. Return self.
 

--- a/bitstring/bitstream.py
+++ b/bitstring/bitstream.py
@@ -624,6 +624,7 @@ class BitStream(ConstBitStream, bitstring.BitArray):
         return s_copy
 
     def __setattr__(self, attribute: str, value) -> None:
+        """Set attributes and reset the bit position when content is replaced."""
         bitstore_id_before = id(self._bitstore) if hasattr(self, '_bitstore') else None
         super().__setattr__(attribute, value)
         # If a dtype property setter replaced the bitstore, reset the bit position.

--- a/tests/test_bitstream.py
+++ b/tests/test_bitstream.py
@@ -3352,7 +3352,6 @@ class TestAllAndAny:
         with pytest.raises(bitstring.ReadError):
             _ = a.read('bytes:4')
 
-    @pytest.mark.skip("Bug #266")
     def test_pos_reset_bug(self):
         a = BitStream('0x0120310230123', pos=23)
         assert a.pos == 23


### PR DESCRIPTION
## Summary

Fixes issue #266: when a dtype property setter (e.g. `a.u8 = 14`) replaces the internal content of a `BitStream`, the bit position `pos` was silently left unchanged instead of being reset to 0.

```python
>>> a = BitStream('0x0120310230123', pos=23)
>>> a.u8 = 14
>>> a.pos  # was 23 — should be 0
23          # BUG: should be 0
```

All other mutating operations (`prepend`, `__setitem__`, `__delitem__`, `insert`) already reset `pos` to 0 after changing the content. This makes the dtype-setter path consistent with the rest of the API.

## Fix

Added `BitStream.__setattr__` that compares the identity of `_bitstore` before and after delegating to `super().__setattr__`. When a dtype setter replaces the bitstore, `_pos` is reset to 0. Removed the `@pytest.mark.skip("Bug #266")` marker from the pre-existing regression test, which now passes.

## Test

```
tests/test_bitstream.py::TestAllAndAny::test_pos_reset_bug PASSED
```

769 tests pass, no regressions introduced.

This pull request was prepared with the assistance of AI, under my direction and review.